### PR TITLE
remove a inline declaration because function of variable parameter cann't define to inline.

### DIFF
--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -25,7 +25,7 @@
 
 namespace limonp {
 using namespace std;
-inline string StringFormat(const char* fmt, ...) {
+string StringFormat(const char* fmt, ...) {
   int size = 256;
   std::string str;
   va_list ap;

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -25,7 +25,7 @@
 
 namespace limonp {
 using namespace std;
-string StringFormat(const char* fmt, ...) {
+inline string StringFormat(const char* fmt, ...) {
   int size = 256;
   std::string str;
   va_list ap;

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -3,7 +3,7 @@
 
 using namespace std;
 
-int main() {
+int main(int argc, char** argv) {
   string strname = "hello, world";
   print(strname); //hello, world
   map<string, int> mp;

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -3,9 +3,9 @@
 
 using namespace std;
 
-int main(int argc, char** argv) {
+int main() {
   string strname = "hello, world";
-  print(strname); //hello, world.
+  print(strname); //hello, world
   map<string, int> mp;
   mp["hello"] = 1;
   mp["world"] = 2;
@@ -16,17 +16,17 @@ int main(int argc, char** argv) {
   print(res); // {"hello": 1, "world": 2}
 
   string str;
-  str = limonp::StringFormat("%s, %s", "hello", "world"); 
-  print(str); //hello, world.
+  str = limonp::StringFormat("%s, %s", "hello", "world");
+  print(str); //hello, world
 
-  const char * a[] = {"hello", "world"}; 
+  const char * a[] = {"hello", "world"};
   str = limonp::Join(a, a + sizeof(a)/sizeof(*a), ",");
-  print(str); //hello, world;
+  print(str); //hello,world
 
   str = "hello, world";
   vector<string> buf;
   limonp::Split(str, buf, ",");
-  print(buf); //["hello", "world"];
+  print(buf); //["hello", "world"]
 
   XLOG(INFO) << "hello, world"; //2014-04-05 20:52:37 demo.cpp:20 INFO hello, world
   //In the same way, `LOG(DEBUG),LOG(WARNING),LOG(ERROR),LOG(FATAL)`.


### PR DESCRIPTION
1. .\include\limonp\StringUtil.hpp|28|: function 'std::string limonp::StringFormat(const char*, ...)' can never be inlined because it uses variable argument lists.

2. the format of some comments in the main function doesn't match the real output of the code.