### PR TITLE
update the annotation of result of print, add Specialized template for vector<string>

### DIFF
--- a/include/limonp/StdExtension.hpp
+++ b/include/limonp/StdExtension.hpp
@@ -38,6 +38,19 @@ ostream& operator << (ostream& os, const vector<T>& v) {
   if(v.empty()) {
     return os << "[]";
   }
+  os<<"["<<v[0];
+  for(size_t i = 1; i < v.size(); i++) {
+    os<<", "<<v[i];
+  }
+  os<<"]";
+  return os;
+}
+
+template<>
+ostream& operator << (ostream& os, const vector<string>& v) {
+  if(v.empty()) {
+    return os << "[]";
+  }
   os<<"[\""<<v[0];
   for(size_t i = 1; i < v.size(); i++) {
     os<<"\", \""<<v[i];

--- a/include/limonp/StdExtension.hpp
+++ b/include/limonp/StdExtension.hpp
@@ -47,7 +47,7 @@ ostream& operator << (ostream& os, const vector<T>& v) {
 }
 
 template<>
-ostream& operator << (ostream& os, const vector<string>& v) {
+inline ostream& operator << (ostream& os, const vector<string>& v) {
   if(v.empty()) {
     return os << "[]";
   }

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -25,7 +25,7 @@
 
 namespace limonp {
 using namespace std;
-string StringFormat(const char* fmt, ...) {
+inline string StringFormat(const char* fmt, ...) {
   int size = 256;
   std::string str;
   va_list ap;

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -9,11 +9,11 @@ int main(int argc, char** argv) {
   map<string, int> mp;
   mp["hello"] = 1;
   mp["world"] = 2;
-  print(mp); // {"hello": 1, "world": 2}
+  print(mp); // {"hello":1, "world":2}
 
   string res;
   res << mp;
-  print(res); // {"hello": 1, "world": 2}
+  print(res); // {"hello":1, "world":2}
 
   string str;
   str = limonp::StringFormat("%s, %s", "hello", "world");
@@ -26,9 +26,9 @@ int main(int argc, char** argv) {
   str = "hello, world";
   vector<string> buf;
   limonp::Split(str, buf, ",");
-  print(buf); //["hello", "world"]
+  print(buf); //["hello", " world"]
 
-  XLOG(INFO) << "hello, world"; //2014-04-05 20:52:37 demo.cpp:20 INFO hello, world
+  XLOG(INFO) << "hello, world"; //2014-04-05 20:52:37 demo.cpp:31 INFO hello, world
   //In the same way, `LOG(DEBUG),LOG(WARNING),LOG(ERROR),LOG(FATAL)`.
   return EXIT_SUCCESS;
 }

--- a/test/demo.cpp
+++ b/test/demo.cpp
@@ -28,7 +28,11 @@ int main(int argc, char** argv) {
   limonp::Split(str, buf, ",");
   print(buf); //["hello", " world"]
 
-  XLOG(INFO) << "hello, world"; //2014-04-05 20:52:37 demo.cpp:31 INFO hello, world
+  int arr[] = {1,10,100,1000};
+  vector<int> vec_i(arr, arr + sizeof(arr)/sizeof(arr[0]));
+  print(vec_i); //[1, 10, 100, 1000]
+
+  XLOG(INFO) << "hello, world"; //2014-04-05 20:52:37 demo.cpp:35 INFO hello, world
   //In the same way, `LOG(DEBUG),LOG(WARNING),LOG(ERROR),LOG(FATAL)`.
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
**1.  update the annotation of result of print:**  
　It's not exactly right before.    
**2.  add Specialized template for `vector<string>` to appoach to style of python:**    
　when it is `vector<string>`, print like this: `["hello", "world"]`; (special case);    
　when it is `vector<int>`, print like this: `[1, 10, 1000]`; (common cases for other types espect `string`)