### PR TITLE
Replace `localtime` with `localtime_s` on Windows and `localtime_r` on Linux

### DIFF
--- a/include/limonp/Logging.hpp
+++ b/include/limonp/Logging.hpp
@@ -52,7 +52,7 @@ class Logger {
     errno_t e = localtime_s(&tmNow, &timeNow);
     assert(e = 0);
     #else
-    struct tm * tm_tmp = localtime_s(&timerNow, tmNow);
+    struct tm * tm_tmp = localtime_s(&timeNow, tmNow);
     assert(tm_tmp != nullptr);
     #endif
 

--- a/include/limonp/Logging.hpp
+++ b/include/limonp/Logging.hpp
@@ -40,10 +40,19 @@ class Logger {
      }
 #endif
     assert(level_ <= sizeof(LOG_LEVEL_ARRAY)/sizeof(*LOG_LEVEL_ARRAY));
+    
     char buf[32];
-    time_t now;
-    time(&now);
-    strftime(buf, sizeof(buf), LOG_TIME_FORMAT, localtime(&now));
+    
+    time_t timeNow;
+    time(&timeNow);
+
+    struct tm tmNow;
+
+    errno_t err = localtime_s(&tmNow, &timeNow);
+    assert(err = 0);
+
+    strftime(buf, sizeof(buf), LOG_TIME_FORMAT, &tmNow);
+    
     stream_ << buf 
       << " " << filename 
       << ":" << lineno 

--- a/include/limonp/Logging.hpp
+++ b/include/limonp/Logging.hpp
@@ -52,7 +52,7 @@ class Logger {
     errno_t e = localtime_s(&tmNow, &timeNow);
     assert(e = 0);
     #else
-    struct tm * tm_tmp = localtime_s(&timeNow, tmNow);
+    struct tm * tm_tmp = localtime_r(&timeNow, tmNow);
     assert(tm_tmp != nullptr);
     #endif
 

--- a/include/limonp/Logging.hpp
+++ b/include/limonp/Logging.hpp
@@ -48,11 +48,16 @@ class Logger {
 
     struct tm tmNow;
 
-    errno_t err = localtime_s(&tmNow, &timeNow);
-    assert(err = 0);
+    #if defined(_WIN32) || defined(_WIN64)
+    errno_t e = localtime_s(&tmNow, &timeNow);
+    assert(e = 0);
+    #else
+    struct tm * tm_tmp = localtime_s(&timerNow, tmNow);
+    assert(tm_tmp != nullptr);
+    #endif
 
     strftime(buf, sizeof(buf), LOG_TIME_FORMAT, &tmNow);
-    
+
     stream_ << buf 
       << " " << filename 
       << ":" << lineno 

--- a/include/limonp/Logging.hpp
+++ b/include/limonp/Logging.hpp
@@ -52,7 +52,7 @@ class Logger {
     errno_t e = localtime_s(&tmNow, &timeNow);
     assert(e = 0);
     #else
-    struct tm * tm_tmp = localtime_r(&timeNow, tmNow);
+    struct tm * tm_tmp = localtime_r(&timeNow, &tmNow);
     assert(tm_tmp != nullptr);
     #endif
 

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <cctype>
 #include <map>
+#include <cassert>
+#include <ctime>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -356,7 +356,7 @@ inline void GetTime(const string& format, string&  timeStr) {
   errno_t e = localtime_s(&tmNow, &timeNow);
   assert(e = 0);
   #else
-  struct tm * tm_tmp = localtime_s(&timerNow, tmNow);
+  struct tm * tm_tmp = localtime_s(&timeNow, tmNow);
   assert(tm_tmp != nullptr);
   #endif
 

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -352,8 +352,13 @@ inline void GetTime(const string& format, string&  timeStr) {
 
   struct tm tmNow;
 
+  #if defined(_WIN32) || defined(_WIN64)
   errno_t e = localtime_s(&tmNow, &timeNow);
   assert(e = 0);
+  #else
+  struct tm * tm_tmp = localtime_s(&timerNow, tmNow);
+  assert(tm_tmp != nullptr);
+  #endif
 
   timeStr.resize(64);
   

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -349,8 +349,16 @@ void GBKTrans(Uint16ContainerConIter begin, Uint16ContainerConIter end, string& 
 inline void GetTime(const string& format, string&  timeStr) {
   time_t timeNow;
   time(&timeNow);
+
+  struct tm tmNow;
+
+  errno_t e = localtime_s(&tmNow, &timeNow);
+  assert(e = 0);
+
   timeStr.resize(64);
-  size_t len = strftime((char*)timeStr.c_str(), timeStr.size(), format.c_str(), localtime(&timeNow));
+  
+  size_t len = strftime((char*)timeStr.c_str(), timeStr.size(), format.c_str(), &tmNow);
+  
   timeStr.resize(len);
 }
 

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -356,7 +356,7 @@ inline void GetTime(const string& format, string&  timeStr) {
   errno_t e = localtime_s(&tmNow, &timeNow);
   assert(e = 0);
   #else
-  struct tm * tm_tmp = localtime_s(&timeNow, tmNow);
+  struct tm * tm_tmp = localtime_r(&timeNow, tmNow);
   assert(tm_tmp != nullptr);
   #endif
 

--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -356,7 +356,7 @@ inline void GetTime(const string& format, string&  timeStr) {
   errno_t e = localtime_s(&tmNow, &timeNow);
   assert(e = 0);
   #else
-  struct tm * tm_tmp = localtime_r(&timeNow, tmNow);
+  struct tm * tm_tmp = localtime_r(&timeNow, &tmNow);
   assert(tm_tmp != nullptr);
   #endif
 


### PR DESCRIPTION
`localtime`在VS2022中默认配置编译时报错（不是警告）