### PR TITLE
To be compatible with cpp17 and later, use lambda instead of std::not1 & std::bind2nd

### DIFF
--- a/include/limonp/StringUtil.hpp
+++ b/include/limonp/StringUtil.hpp
@@ -86,12 +86,12 @@ inline bool IsSpace(unsigned c) {
 }
 
 inline std::string& LTrim(std::string &s) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))));
+  s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](const char & c) { return !IsSpace(c); }));
   return s;
 }
 
 inline std::string& RTrim(std::string &s) {
-  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::ptr_fun<unsigned, bool>(IsSpace))).base(), s.end());
+  s.erase(std::find_if(s.rbegin(), s.rend(), [](const char & c) { return !IsSpace(c); }).base(), s.end());
   return s;
 }
 
@@ -100,12 +100,12 @@ inline std::string& Trim(std::string &s) {
 }
 
 inline std::string& LTrim(std::string & s, char x) {
-  s.erase(s.begin(), std::find_if(s.begin(), s.end(), std::not1(std::bind2nd(std::equal_to<char>(), x))));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [&x](const char & c) { return c != x; }));
   return s;
 }
 
 inline std::string& RTrim(std::string & s, char x) {
-  s.erase(std::find_if(s.rbegin(), s.rend(), std::not1(std::bind2nd(std::equal_to<char>(), x))).base(), s.end());
+  s.erase(std::find_if(s.rbegin(), s.rend(), [&x](const char & c) { return c != x; }).base(), s.end());
   return s;
 }
 


### PR DESCRIPTION
Compiling with C++ 17 by MSVC failed because
* std::not1
* std::bind2nd

have been deprecated since C++ 17.

To solve it, use lambda instead.