### PR TITLE
Update checkout action in CMake workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -28,7 +28,7 @@ jobs:
         build_type: [Release, Debug]
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DBUILD_TESTING=ON -DCMAKE_CXX_STANDARD=${{matrix.cpp_version}} -DCMAKE_BUILD_TYPE=${{matrix.build_type}}


### PR DESCRIPTION
## Summary
- update the CMake workflow from `actions/checkout@v5` to `actions/checkout@v6`
- preserve the existing OS, C++ standard, and build type matrix

## Context
- Existing runner matrix already covers explicit baseline runners plus current `*-latest` labels.

## Testing
- Not run locally; workflow-only change.