### PR TITLE
[codex] Add macOS 26 CI coverage

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,6 +21,7 @@ jobs:
           ubuntu-latest,
           macos-14,
           macos-15,
+          macos-26,
           windows-2022,
           windows-latest,
         ]  


### PR DESCRIPTION
## Summary

- Add `macos-26` to the CMake workflow OS matrix.
- Keep existing Ubuntu, Windows, macOS 14, and macOS 15 coverage.

## Rationale

GitHub-hosted runners now include macOS 26 labels, so this expands routine compatibility coverage to the latest available macOS runner image.

## Validation

- Workflow-only change; validation is the pull request CMake matrix.