### PR TITLE
Modernize LocalVector helper

### DIFF
--- a/include/limonp/LocalVector.hpp
+++ b/include/limonp/LocalVector.hpp
@@ -2,123 +2,63 @@
 #define LIMONP_LOCAL_VECTOR_HPP
 
 #include <iostream>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>
+#include <vector>
 
 namespace limonp {
 using namespace std;
-/*
- * LocalVector<T> : T must be primitive type (char , int, size_t), if T is struct or class, LocalVector<T> may be dangerous..
- * LocalVector<T> is simple and not well-tested.
- */
-const size_t LOCAL_VECTOR_BUFFER_SIZE = 16;
+
 template <class T>
 class LocalVector {
  public:
-  typedef const T* const_iterator ;
+  typedef const T* const_iterator;
   typedef T value_type;
   typedef size_t size_type;
- private:
-  T buffer_[LOCAL_VECTOR_BUFFER_SIZE];
-  T * ptr_;
-  size_t size_;
-  size_t capacity_;
- public:
-  LocalVector() {
-    init_();
-  };
-  LocalVector(const LocalVector<T>& vec) {
-    init_();
-    *this = vec;
+
+  LocalVector() {}
+  LocalVector(const_iterator begin, const_iterator end) : data_(begin, end) {}
+  LocalVector(size_t size, const T& t) : data_(size, t) {}
+
+  T& operator[](size_t i) {
+    return data_[i];
   }
-  LocalVector(const_iterator  begin, const_iterator end) { // TODO: make it faster
-    init_();
-    while(begin != end) {
-      push_back(*begin++);
-    }
+  const T& operator[](size_t i) const {
+    return data_[i];
   }
-  LocalVector(size_t size, const T& t) { // TODO: make it faster
-    init_();
-    while(size--) {
-      push_back(t);
-    }
-  }
-  ~LocalVector() {
-    if(ptr_ != buffer_) {
-      free(ptr_);
-    }
-  };
- public:
-  LocalVector<T>& operator = (const LocalVector<T>& vec) {
-    clear();
-    size_ = vec.size();
-    capacity_ = vec.capacity();
-    if(vec.buffer_ == vec.ptr_) {
-      memcpy(static_cast<void*>(buffer_), vec.buffer_, sizeof(T) * size_);
-      ptr_ = buffer_;
-    } else {
-      ptr_ = (T*) malloc(vec.capacity() * sizeof(T));
-      assert(ptr_);
-      memcpy(static_cast<void*>(ptr_), vec.ptr_, vec.size() * sizeof(T));
-    }
-    return *this;
-  }
- private:
-  void init_() {
-    ptr_ = buffer_;
-    size_ = 0;
-    capacity_ = LOCAL_VECTOR_BUFFER_SIZE;
-  }
- public:
-  T& operator [] (size_t i) {
-    return ptr_[i];
-  }
-  const T& operator [] (size_t i) const {
-    return ptr_[i];
-  }
-  void push_back(const T& t) {
-    if(size_ == capacity_) {
-      assert(capacity_);
-      reserve(capacity_ * 2);
-    }
-    ptr_[size_ ++ ] = t;
+
+  void push_back(const T& value) {
+    data_.push_back(value);
   }
   void reserve(size_t size) {
-    if(size <= capacity_) {
-      return;
-    }
-    T * next =  (T*)malloc(sizeof(T) * size);
-    assert(next);
-    T * old = ptr_;
-    ptr_ = next;
-    memcpy(static_cast<void*>(ptr_), old, sizeof(T) * capacity_);
-    capacity_ = size;
-    if(old != buffer_) {
-      free(old);
-    }
+    data_.reserve(size);
   }
   bool empty() const {
-    return 0 == size();
+    return data_.empty();
   }
   size_t size() const {
-    return size_;
+    return data_.size();
   }
   size_t capacity() const {
-    return capacity_;
+    return data_.capacity();
   }
   const_iterator begin() const {
-    return ptr_;
+    return data_.data();
   }
   const_iterator end() const {
-    return ptr_ + size_;
+    return data_.data() + data_.size();
   }
   void clear() {
-    if(ptr_ != buffer_) {
-      free(ptr_);
-    }
-    init_();
+    data_.clear();
   }
+
+  bool operator==(const LocalVector<T>& rhs) const {
+    return data_ == rhs.data_;
+  }
+  bool operator!=(const LocalVector<T>& rhs) const {
+    return !(*this == rhs);
+  }
+
+ private:
+  vector<T> data_;
 };
 
 template <class T>

--- a/include/limonp/StdExtension.hpp
+++ b/include/limonp/StdExtension.hpp
@@ -3,10 +3,7 @@
 
 #include <map>
 
-#ifdef __APPLE__
-#include <unordered_map>
-#include <unordered_set>
-#elif(__cplusplus >= 201103L)
+#if defined(__APPLE__) || __cplusplus >= 201103L
 #include <unordered_map>
 #include <unordered_set>
 #elif defined _MSC_VER

--- a/test/unittest/TLocalVector.cpp
+++ b/test/unittest/TLocalVector.cpp
@@ -8,34 +8,47 @@ using namespace limonp;
 TEST(LocalVector, test1) {
   LocalVector<size_t> vec;
   ASSERT_EQ(vec.size(), 0u);
-  ASSERT_EQ(vec.capacity(), LOCAL_VECTOR_BUFFER_SIZE);
+  ASSERT_EQ(vec.capacity(), 0u);
   ASSERT_TRUE(vec.empty());
   size_t size = 129;
   for(size_t i = 0; i < size; i++) {
     vec.push_back(i);
   }
   ASSERT_EQ(vec.size(), size);
-  ASSERT_EQ(vec.capacity(), 256u);
+  ASSERT_GE(vec.capacity(), size);
   ASSERT_FALSE(vec.empty());
+  const size_t* begin = vec.begin();
+  ASSERT_EQ(begin[0], 0u);
   LocalVector<size_t> vec2(vec);
-  ASSERT_EQ(vec2.capacity(), vec.capacity());
   ASSERT_EQ(vec2.size(), vec.size());
+  ASSERT_EQ(vec2, vec);
 }
 
 TEST(LocalVector, test2) {
   LocalVector<size_t> vec;
   ASSERT_EQ(vec.size(), 0u);
-  ASSERT_EQ(vec.capacity(), LOCAL_VECTOR_BUFFER_SIZE);
+  ASSERT_EQ(vec.capacity(), 0u);
   ASSERT_TRUE(vec.empty());
   size_t size = 1;
   for(size_t i = 0; i < size; i++) {
     vec.push_back(i);
   }
   ASSERT_EQ(vec.size(), size);
-  ASSERT_EQ(vec.capacity(), LOCAL_VECTOR_BUFFER_SIZE);
+  ASSERT_GE(vec.capacity(), size);
   ASSERT_FALSE(vec.empty());
   LocalVector<size_t> vec2;
   vec2 = vec;
-  ASSERT_EQ(vec2.capacity(), vec.capacity());
   ASSERT_EQ(vec2.size(), vec.size());
+  ASSERT_EQ(vec2, vec);
+}
+
+TEST(LocalVector, NonTrivialValue) {
+  LocalVector<std::string> vec;
+  vec.push_back("alpha");
+  vec.push_back("beta");
+  LocalVector<std::string> vec2(vec);
+  ASSERT_EQ(vec2, vec);
+
+  LocalVector<std::string> vec3(vec.begin(), vec.end());
+  ASSERT_EQ(vec3, vec);
 }


### PR DESCRIPTION
## Summary
- Replace `LocalVector`'s manual buffer management with a `std::vector`-backed compatibility wrapper.
- Use standard unordered containers for Apple or any C++11-and-newer compiler mode in `StdExtension.hpp`.
- Update `TLocalVector` to stop depending on the old fixed buffer capacity and add a non-trivial value regression case.

This forward-ports the helper modernization from yanyiwu/libcppjieba#6 and completes the corresponding limonp unit test updates.

## Validation
- `cmake -S . -B /private/tmp/limonp-pr-build`
- `cmake --build /private/tmp/limonp-pr-build`
- `/private/tmp/limonp-pr-build/test/test.run` from the source `test` directory

Note: `ctest --test-dir /private/tmp/limonp-pr-build --output-on-failure` currently runs `./test/demo` successfully but cannot find `./test/test.run`; the unit test binary is generated at `/private/tmp/limonp-pr-build/test/test.run`, so I ran it directly from the source `test` directory to satisfy the tests' relative testdata paths.